### PR TITLE
Fix taskpaper#update_project function

### DIFF
--- a/autoload/taskpaper.vim
+++ b/autoload/taskpaper.vim
@@ -328,7 +328,7 @@ function! taskpaper#update_project()
 
     for linenr in range(line('.'), 1, -1)
         let line = getline(linenr)
-        let ml = matchlist(line, '\v^\t{0,' . depth . '}([^\t:]+):')
+        let ml = matchlist(line, '\v^\t{0,' . depth . '}([^\t:]+):$')
         if empty(ml)
             continue
         endif

--- a/autoload/taskpaper.vim
+++ b/autoload/taskpaper.vim
@@ -75,6 +75,7 @@ function! taskpaper#has_tag(tag)
         return 1
     else
         return 0
+    endif
 endfunction
 
 function! taskpaper#cycle_tags(...)


### PR DESCRIPTION
add $ to the end of matchlist pattern to avoid adding projects/tasks
which might have a @done tag, that includes a ':'. E.g @done(2020-03-07 12:12)